### PR TITLE
improvement : exceptions with error description message

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Note that from a probabilistic viewpoint, GCO works in log-space.
 Note that all input arrays are assumed to be in int32.
 This means that float potentials must be rounded!
 
-These algorithms can only deal with certain energies. Unfortunately
-I have not figured out yet how to convert C++ errors to Python. If an unknown
+These algorithms can only deal with certain energies. If an 
 error is raised, it probably means that you used an invalid energy function.
 Look at the gco README for details.
 

--- a/gco_exception_handler.cpp
+++ b/gco_exception_handler.cpp
@@ -1,0 +1,29 @@
+#include "Python.h"
+#include "GCoptimization.h"
+#include <exception>
+#include <string>
+
+using namespace std;
+
+extern PyObject *gcerror; // a python exception object that represents the graph cut exception in python
+
+/**
+	\brief	this function translates graph cut exceptions into python exceptions.
+	
+	It uses the mechanism described in http://stackoverflow.com/questions/10684983/handling-custom-c-exceptions-in-cython
+*/
+void handle_gco_exception()
+{
+	try
+	{
+		throw;
+	}
+	catch (GCException& e)
+	{
+		PyErr_SetString(gcerror, e.message);
+	}
+	catch (const std::exception& e)
+	{
+		PyErr_SetString(PyExc_RuntimeError, e.what() );
+	}
+}

--- a/gco_exception_handler.hpp
+++ b/gco_exception_handler.hpp
@@ -1,0 +1,1 @@
+void handle_gco_exception();

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ files = ['GCoptimization.cpp', 'graph.cpp', 'LinkedBlockList.cpp',
          'maxflow.cpp']
 
 files = [os.path.join(gco_directory, f) for f in files]
+files.insert(0, "gco_exception_handler.cpp")
 files.insert(0, "gco_python.pyx")
 
 setup(cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
Hi, I made some modifications so that from now on, whenever an exception is raised in the graph cut c++ code, the message detailing the reason of the failure is displayed (graph-cut c++ exceptions are translated into python exceptions).
Without this change, whenever the graph code fails, a c++ exception (with a message detailing the reason of failure) is raised, but the description of the error is lost when translated into python exception: as a result, the user has no message to help him to understand why graph cut optimization failed.